### PR TITLE
Drop python3.7 from github action that runs tests

### DIFF
--- a/djimaging/autorois/roi_canvas.py
+++ b/djimaging/autorois/roi_canvas.py
@@ -1,4 +1,4 @@
-import os.path  # noqa: E999
+import os.path
 import pickle
 import warnings
 from datetime import datetime


### PR DESCRIPTION
TIL: Remove python3.7 from the github actions as it does not successfully run the tests with the current code and as python3.7 is [out of life](https://devguide.python.org/versions/).

## Longer Description
On the current main branch flake complains about the `import os.path` error when using python3.7 ([github action link of erroneous run](https://github.com/eulerlab/djimaging/actions/runs/9176545564/job/25232054285)):
```
 ./djimaging/autorois/roi_canvas.py:1:14: E999 SyntaxError: invalid syntax
import os.path
             ^
1     E999 SyntaxError: invalid syntax
1
Error: Process completed with exit code 1.
```

I think this is a mistake by flake, and I added a `# noqa` comment to this line.

With python 3.7 I afterwards got the following error:
```
>   from djimaging.autorois.roi_canvas import InteractiveRoiCanvas
E     File "<fstring>", line 1
E       (missing_only=)
E                    ^
E   SyntaxError: invalid syntax
```

It turned out that the `import os.path` error only appeared with 3.7. I removed python3.7 from the automatic tests, it is out of life anyway according to the [status of python versions](https://devguide.python.org/versions/).