### PR TITLE
Work in progress: Github workflow, djimaging integration test using mysql 8

### DIFF
--- a/.github/workflows/mysql-integration.yml
+++ b/.github/workflows/mysql-integration.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/mysql-integration.yml
+++ b/.github/workflows/mysql-integration.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv pip install --system pytest "setuptools<81" -e . # uv pip install --system pytest "setuptools<81" "datajoint==0.14.7" -e .
+        run: uv pip install --system pytest "setuptools<81" "datajoint==0.14.7" -e .
 
       - name: Run MySQL integration tests
         env:

--- a/.github/workflows/mysql-integration.yml
+++ b/.github/workflows/mysql-integration.yml
@@ -37,10 +37,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install dependencies
-        run: uv pip install --system pytest "setuptools<81" "datajoint==0.14.7" -e .
+        run: uv pip install --system pytest "setuptools<81" -e . # uv pip install --system pytest "setuptools<81" "datajoint==0.14.7" -e .
 
       - name: Run MySQL integration tests
         env:

--- a/.github/workflows/mysql-integration.yml
+++ b/.github/workflows/mysql-integration.yml
@@ -1,0 +1,53 @@
+name: MySQL integration testing
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0.43
+        env:
+          MYSQL_ROOT_PASSWORD: datajoint
+          MYSQL_ROOT_HOST: "%"
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -pdatajoint"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: uv pip install --system pytest "setuptools<81" "datajoint==0.14.7" -e .
+
+      - name: Run MySQL integration tests
+        env:
+          DJ_TEST_MYSQL: "1"
+          DJ_HOST: 127.0.0.1
+          DJ_PORT: "3306"
+          DJ_USER: root
+          DJ_PASS: datajoint
+        run: pytest -q tests/integration

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   test:
@@ -32,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install --system flake8 pytest
-          uv pip install --system -e .
+          uv pip install --system "setuptools<81" "datajoint==0.14.7" -e .
 
       - name: Lint with flake8
         run: |
@@ -41,4 +40,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest -v
+          pytest -v tests --ignore=tests/integration

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12" ]
+        python-version: [ "3.12", "3.13", "3.14" ]
 
     steps:
       - name: Checkout repo

--- a/README.md
+++ b/README.md
@@ -67,3 +67,31 @@ calling <code>schema.drop()</code> and confirm by entering <code>yes</code>.
 
 > ⚠️ Make sure you only drop your own schema! <code>schema.drop()</code> will show you the name of the schema.
 > If you are not sure about the schema's origin, don't drop it!
+
+## Local testing
+
+Install the test environment with DataJoint 0.14.7:
+
+```bash
+uv pip install pytest "setuptools<81" "datajoint==0.14.7" -e .
+```
+
+Run unit tests:
+
+```bash
+pytest -q tests --ignore=tests/integration
+```
+
+Run integration tests against a temporary MySQL 8.0.43 server:
+
+```bash
+docker run --rm --name djimaging-mysql-test \
+  -e MYSQL_ROOT_PASSWORD=datajoint -e MYSQL_ROOT_HOST=% \
+  -p 3307:3306 -d mysql:8.0.43
+until docker exec djimaging-mysql-test mysqladmin ping -h 127.0.0.1 -pdatajoint; do sleep 1; done
+
+DJ_TEST_MYSQL=1 DJ_HOST=127.0.0.1 DJ_PORT=3307 \
+DJ_USER=root DJ_PASS=datajoint pytest -q tests/integration
+
+docker stop djimaging-mysql-test
+```

--- a/tests/autorois/test_autoshift.py
+++ b/tests/autorois/test_autoshift.py
@@ -10,11 +10,6 @@ from djimaging.utils.scanm import read_h5_utils
 
 _TEST_DATA_PATH = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', 'test_data'))
 
-pytestmark = pytest.mark.skipif(
-    not os.path.isdir(_TEST_DATA_PATH),
-    reason="test_data directory not found (skipped on CI)"
-)
-
 params_test_shit_img = [
     (0, 0),
     (1, 0),

--- a/tests/autorois/test_autoshift_synthetic.py
+++ b/tests/autorois/test_autoshift_synthetic.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import pytest
+
+from djimaging.autorois.autoshift_utils import (
+    compute_corr_map,
+    compute_corr_map_match_indexes,
+    extract_best_shift,
+    shift_img,
+)
+from djimaging.utils.scanm import read_h5_utils
+
+
+PARAMS_TEST_AUTOSHIFT = [
+    (0, -1, 3, 'corr'),
+    (-1, -1, 3, 'corr'),
+    (-2, 2, 5, 'corr'),
+    (0, 0, 3, 'mse'),
+    (1, 0, 3, 'mse'),
+    (0, 1, 3, 'mse'),
+    (1, 1, 3, 'mse'),
+    (-1, 0, 3, 'mse'),
+    (0, -1, 3, 'mse'),
+    (-1, -1, 3, 'mse'),
+    (-2, 2, 5, 'mse'),
+]
+
+
+@pytest.fixture(scope="module")
+def synthetic_stack(synthetic_recording_path: Callable[[str], Path]) -> np.ndarray:
+    ch_stacks, _ = read_h5_utils.load_stacks_and_wparams(
+        str(synthetic_recording_path("chirp")), ch_names=('wDataCh0',)
+    )
+    return ch_stacks['wDataCh0']
+
+
+@pytest.mark.parametrize("shift_x, shift_y, shift_max, metric", PARAMS_TEST_AUTOSHIFT)
+def test_autoshift_synthetic_stack(shift_x, shift_y, shift_max, metric, synthetic_stack):
+    ref_corr = compute_corr_map(synthetic_stack)
+    shifted_corr = shift_img(ref_corr, shift_x, shift_y)
+    match_indexes = compute_corr_map_match_indexes(
+        shifted_corr, ref_corr, shift_max, metric=metric
+    )
+
+    obs_shift_x, obs_shift_y = extract_best_shift(match_indexes)
+
+    assert obs_shift_x == shift_x and obs_shift_y == shift_y

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from tests.fixtures.synthetic_scanm import (
+    EXPERIMENT_DAY,
+    EXPERIMENT_NUMBER,
+    RECORDING_PREFIX,
+    generate_tutorial_dataset,
+)
+
+
+@pytest.fixture(scope="session")
+def tutorial_data_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return generate_tutorial_dataset(tmp_path_factory.mktemp("synthetic_scanm_data"))
+
+
+@pytest.fixture(scope="session")
+def synthetic_recording_path(tutorial_data_dir: Path) -> Callable[[str], Path]:
+    pre_dir = tutorial_data_dir / EXPERIMENT_DAY / EXPERIMENT_NUMBER / "Pre"
+
+    def get_recording(stimulus: str) -> Path:
+        return pre_dir / f"{RECORDING_PREFIX}_{stimulus}_TEST.h5"
+
+    return get_recording

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers that create test data at runtime."""

--- a/tests/fixtures/random_utils.py
+++ b/tests/fixtures/random_utils.py
@@ -1,0 +1,13 @@
+from contextlib import contextmanager
+
+import numpy as np
+
+
+@contextmanager
+def numpy_seed(seed):
+    state = np.random.get_state()
+    np.random.seed(seed)
+    try:
+        yield
+    finally:
+        np.random.set_state(state)

--- a/tests/fixtures/synthetic_scanm.py
+++ b/tests/fixtures/synthetic_scanm.py
@@ -1,0 +1,273 @@
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+
+NX = 8
+NY = 8
+FRAME_DT = 0.1
+PIXEL_DURATION_US = FRAME_DT / (NX * NY) * 1e6
+STIMULATOR_DELAY_MS = 2.0
+TRIGGER_X_INDEX = 1
+EXPERIMENT_DAY = "20990101"
+EXPERIMENT_NUMBER = "1"
+RECORDING_PREFIX = "SYN_SUBJECT_REGION_FIELD0"
+
+RECORDING_SPECS = {
+    "chirp": {
+        "n_frames": 900,
+        "trigger_times": np.array(
+            [time for start in 7.0 + 16.0 * np.arange(5) for time in (start, start + 4.0)]
+        ),
+    },
+    "MB": {
+        "n_frames": 1200,
+        "trigger_times": 7.0 + 4.5 * np.arange(24),
+    },
+    "DN": {
+        "n_frames": 3100,
+        "trigger_times": 7.0 + 0.2 * np.arange(1500),
+    },
+}
+
+
+def generate_tutorial_dataset(root: Path, seed: int = 42) -> Path:
+    """Create a small xy-RGC dataset that follows the tutorial's file layout."""
+    root = Path(root)
+    experiment_dir = root / EXPERIMENT_DAY / EXPERIMENT_NUMBER
+    pre_dir = experiment_dir / "Pre"
+    pre_dir.mkdir(parents=True, exist_ok=True)
+    (experiment_dir / "Raw").mkdir(exist_ok=True)
+
+    (experiment_dir / "synthetic__left.ini").write_text(_experiment_ini(), encoding="utf-8")
+
+    rng = np.random.default_rng(seed)
+    roi_mask = _roi_mask()
+    for stimulus, spec in RECORDING_SPECS.items():
+        filepath = pre_dir / f"{RECORDING_PREFIX}_{stimulus}_TEST.h5"
+        _write_recording(
+            filepath=filepath,
+            stimulus=stimulus,
+            n_frames=spec["n_frames"],
+            requested_trigger_times=spec["trigger_times"],
+            roi_mask=roi_mask,
+            rng=rng,
+        )
+
+    resources_dir = root / "resources"
+    resources_dir.mkdir(exist_ok=True)
+    noise = rng.choice(np.array([-1, 1], dtype=np.int8), size=(1500, 15, 20))
+    with h5py.File(resources_dir / "noise.h5", "w") as h5_file:
+        h5_file.create_dataset("stimulusarray", data=noise, compression="gzip", compression_opts=1)
+
+    return root
+
+
+def expected_trace_times(
+        roi_mask: np.ndarray, n_frames: int, precision: str = "line") -> np.ndarray:
+    """Calculate synthetic ROI timestamps directly from the scan geometry."""
+    if precision not in {"line", "pixel"}:
+        raise ValueError(f"Unknown precision: {precision}")
+
+    pixel_dt = PIXEL_DURATION_US * 1e-6
+    frame_times = np.arange(n_frames) * FRAME_DT
+    roi_ids = np.unique(roi_mask)
+    roi_ids = roi_ids[roi_ids < 0]
+    roi_ids = roi_ids[np.argsort(np.abs(roi_ids))]
+    trace_times = np.empty((n_frames, len(roi_ids)), dtype=float)
+
+    x_indexes, y_indexes = np.indices(roi_mask.shape)
+    for column, roi_id in enumerate(roi_ids):
+        in_roi = roi_mask == roi_id
+        if precision == "line":
+            offsets = y_indexes[in_roi] * NX * pixel_dt
+        else:
+            offsets = (y_indexes[in_roi] * NX + x_indexes[in_roi]) * pixel_dt
+        trace_times[:, column] = frame_times + np.median(offsets)
+
+    return trace_times
+
+
+def _write_recording(
+        filepath: Path,
+        stimulus: str,
+        n_frames: int,
+        requested_trigger_times: np.ndarray,
+        roi_mask: np.ndarray,
+        rng: np.random.Generator,
+) -> None:
+    frame_times = np.arange(n_frames) * FRAME_DT
+    trigger_stack, trigger_times = _trigger_stack(n_frames, requested_trigger_times)
+
+    data_stack = rng.normal(10_000, 4, size=(NX, NY, n_frames))
+    for roi_id in (1, 2):
+        response = _response(stimulus, frame_times, trigger_times, roi_id, rng)
+        roi_pixels = roi_mask == -roi_id
+        data_stack[roi_pixels, :] += response
+
+    data_stack = _as_uint16(data_stack)
+
+    alt_stack = rng.normal(11_000, 3, size=(NX, NY, n_frames))
+    alt_stack[roi_mask == -1, :] += 250
+    alt_stack[roi_mask == -2, :] += 500
+
+    alt_stack = _as_uint16(alt_stack)
+
+    roi_ids = np.unique(roi_mask)
+    roi_ids = roi_ids[roi_ids < 0]
+    roi_ids = roi_ids[np.argsort(np.abs(roi_ids))]
+    traces = np.column_stack([
+        np.mean(data_stack[roi_mask == roi_id], axis=0) for roi_id in roi_ids
+    ])
+    trace_times = expected_trace_times(roi_mask, n_frames, precision="line")
+
+    with h5py.File(filepath, "w") as h5_file:
+        _write_stack(h5_file, "wDataCh0", data_stack)
+        _write_stack(h5_file, "wDataCh1", alt_stack)
+        _write_stack(h5_file, "wDataCh2", trigger_stack)
+        h5_file.create_dataset("ROIs", data=roi_mask.astype(np.int16))
+        h5_file.create_dataset("Traces0_raw", data=traces)
+        h5_file.create_dataset(
+            "Tracetimes0", data=trace_times + STIMULATOR_DELAY_MS / 1000
+        )
+        h5_file.create_dataset("Triggertimes", data=trigger_times)
+        h5_file.create_dataset(
+            "Triggervalues", data=np.full(trigger_times.size, 60_000, dtype=np.float32)
+        )
+        _write_wparams_num(h5_file)
+        _write_os_params(h5_file)
+
+
+def _write_stack(h5_file: h5py.File, name: str, values: np.ndarray) -> None:
+    h5_file.create_dataset(
+        name,
+        data=values,
+        compression="gzip",
+        compression_opts=1,
+        shuffle=True,
+    )
+
+
+def _as_uint16(values: np.ndarray) -> np.ndarray:
+    return np.clip(np.rint(values), 0, np.iinfo(np.uint16).max).astype(np.uint16)
+
+
+def _write_wparams_num(h5_file: h5py.File) -> None:
+    params = {
+        "User_dxPix": NX,
+        "User_dyPix": NY,
+        "User_dzPix": 0,
+        "User_nPixRetrace": 0,
+        "User_nXPixLineOffs": 0,
+        "RealPixDur": PIXEL_DURATION_US,
+        "Zoom": 1,
+        "Angle_deg": 0,
+        "XCoord_um": 123,
+        "YCoord_um": 245,
+        "ZCoord_um": 9,
+        "ZStep_um": 1,
+        "User_ScanType": 10,
+    }
+    dataset = h5_file.create_dataset("wParamsNum", data=np.asarray(list(params.values()), dtype=np.float32))
+
+    labels = np.full((len(params) + 1, 1), "", dtype=h5py.string_dtype(encoding="utf-8"))
+    labels[1:, 0] = list(params)
+    dataset.attrs["IGORWaveDimensionLabels"] = labels
+
+
+def _write_os_params(h5_file: h5py.File) -> None:
+    dataset = h5_file.create_dataset(
+        "OS_Parameters", data=np.asarray([STIMULATOR_DELAY_MS], dtype=np.float32)
+    )
+    labels = np.full((2, 1), "", dtype=h5py.string_dtype(encoding="utf-8"))
+    labels[1, 0] = "StimulatorDelay"
+    dataset.attrs["IGORWaveDimensionLabels"] = labels
+
+
+def _trigger_stack(n_frames: int, requested_times: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    stack = np.full((NX, NY, n_frames), 10_000, dtype=np.uint16)
+    line_dt = FRAME_DT / NY
+    line_indices = np.rint(np.asarray(requested_times) / line_dt).astype(int)
+
+    for line_index in line_indices:
+        frame_index, y_index = divmod(line_index, NY)
+        if frame_index >= n_frames:
+            raise ValueError(f"Trigger at line {line_index} is outside a {n_frames}-frame recording")
+        stack[TRIGGER_X_INDEX:, y_index, frame_index] = 60_000
+
+    pixel_dt = PIXEL_DURATION_US * 1e-6
+    return stack, line_indices * line_dt + TRIGGER_X_INDEX * pixel_dt
+
+
+def _response(
+        stimulus: str,
+        frame_times: np.ndarray,
+        trigger_times: np.ndarray,
+        roi_id: int,
+        rng: np.random.Generator,
+) -> np.ndarray:
+    response = rng.normal(0, 2, size=frame_times.size)
+
+    if stimulus == "chirp":
+        scale = 1.0 if roi_id == 1 else 0.7
+        for start in trigger_times[::2]:
+            rel_time = frame_times - start
+            active = (rel_time >= 0) & (rel_time < 14)
+            pattern = (
+                100 * np.exp(-((rel_time - 2) / 0.8) ** 2)
+                - 70 * np.exp(-((rel_time - 7) / 1.2) ** 2)
+                + 45 * np.sin(2 * np.pi * rel_time / 4)
+                + 25 * np.sin(2 * np.pi * rel_time ** 2 / 90)
+            )
+            response[active] += scale * pattern[active]
+    elif stimulus == "MB":
+        directions = np.array([0, 180, 45, 225, 90, 270, 135, 315])
+        preferred_direction = 0 if roi_id == 1 else 90
+        for index, start in enumerate(trigger_times):
+            rel_time = frame_times - start
+            active = (rel_time >= 0) & (rel_time < 3.8)
+            direction = directions[index % directions.size]
+            direction_gain = 1 + 0.75 * np.cos(np.deg2rad(direction - preferred_direction))
+            time_kernel = (
+                80 * np.exp(-((rel_time - 1.7) / 0.45) ** 2)
+                + 35 * np.exp(-((rel_time - 3.0) / 0.35) ** 2)
+            )
+            response[active] += direction_gain * time_kernel[active]
+    elif stimulus == "DN":
+        response += rng.normal(0, 15 if roi_id == 1 else 10, size=frame_times.size)
+    else:
+        raise ValueError(f"Unknown stimulus: {stimulus}")
+
+    return response
+
+
+def _roi_mask() -> np.ndarray:
+    roi_mask = np.ones((NX, NY), dtype=np.int16)
+    roi_mask[3:5, 1:3] = -1
+    roi_mask[5:7, 5:7] = -2
+    return roi_mask
+
+
+def _experiment_ini() -> str:
+    return """[Project]
+string_projName=Synthetic tutorial data
+string_date=2099-01-01
+string_setupID=3
+
+[Animal]
+string_animSpecies=synthetic
+string_animGender=unknown
+string_eye=left
+
+[Preparation]
+string_prep=wholemount
+string_prepWMOpticDiscPos=111;222;3
+uint8_prepWMOrient=0
+
+[Pharmacology]
+string_pharmDrug=none
+string_pharmDrugConc_um=
+string_preTime=
+string_pharmRem=
+"""

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Tests that require a live database."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 
 @pytest.fixture(scope="session")
-def core_schema():
+def tutorial_schema():
     dj.config["database.host"] = os.environ.get("DJ_HOST", "127.0.0.1")
     dj.config["database.port"] = int(os.environ.get("DJ_PORT", "3306"))
     dj.config["database.user"] = os.environ.get("DJ_USER", "root")
@@ -15,7 +15,7 @@ def core_schema():
     connection = dj.conn()
     schema_name = f"djimaging_ci_{uuid.uuid4().hex[:8]}"
 
-    from djimaging.schemas import core_schema as schema_module
+    from djimaging.schemas import tutorial_schema as schema_module
     from djimaging.utils.dj_utils import activate_schema
 
     try:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,25 @@
+import os
+import uuid
+
+import datajoint as dj
+import pytest
+
+
+@pytest.fixture(scope="session")
+def core_schema():
+    dj.config["database.host"] = os.environ.get("DJ_HOST", "127.0.0.1")
+    dj.config["database.port"] = int(os.environ.get("DJ_PORT", "3306"))
+    dj.config["database.user"] = os.environ.get("DJ_USER", "root")
+    dj.config["database.password"] = os.environ.get("DJ_PASS", "datajoint")
+
+    connection = dj.conn()
+    schema_name = f"djimaging_ci_{uuid.uuid4().hex[:8]}"
+
+    from djimaging.schemas import core_schema as schema_module
+    from djimaging.utils.dj_utils import activate_schema
+
+    try:
+        activate_schema(schema_module.schema, schema_name=schema_name)
+        yield schema_module
+    finally:
+        connection.query(f"DROP DATABASE IF EXISTS `{schema_name}`")

--- a/tests/integration/test_core_schema.py
+++ b/tests/integration/test_core_schema.py
@@ -9,13 +9,12 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_core_tables_are_declared(core_schema):
-    assert "experimenter" in core_schema.UserInfo().heading.names
-    assert "raw_id" in core_schema.RawDataParams().heading.names
+def test_all_tutorial_tables_initialize(tutorial_schema):
+    assert tutorial_schema.schema.list_tables()
 
 
-def test_user_info_round_trip(core_schema, tmp_path):
-    user_info = core_schema.UserInfo()
+def test_user_info_round_trip(tutorial_schema, tmp_path):
+    user_info = tutorial_schema.UserInfo()
     user_info.upload_user(
         {
             "experimenter": "ci_user",
@@ -30,8 +29,8 @@ def test_user_info_round_trip(core_schema, tmp_path):
     assert row["data_dir"] == f"{tmp_path}/"
 
 
-def test_add_default_raw_data_params(core_schema, tmp_path):
-    core_schema.UserInfo().upload_user(
+def test_add_default_raw_data_params(tutorial_schema, tmp_path):
+    tutorial_schema.UserInfo().upload_user(
         {
             "experimenter": "ci_params",
             "data_dir": str(tmp_path),
@@ -41,7 +40,7 @@ def test_add_default_raw_data_params(core_schema, tmp_path):
         verbose=0,
     )
 
-    raw_data_params = core_schema.RawDataParams()
+    raw_data_params = tutorial_schema.RawDataParams()
     raw_data_params.add_default(experimenter_list=["ci_params"])
 
     row = (raw_data_params & {"experimenter": "ci_params"}).fetch1()

--- a/tests/integration/test_core_schema.py
+++ b/tests/integration/test_core_schema.py
@@ -1,0 +1,49 @@
+import os
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DJ_TEST_MYSQL") != "1",
+    reason="requires the MySQL integration-test service",
+)
+
+
+def test_core_tables_are_declared(core_schema):
+    assert "experimenter" in core_schema.UserInfo().heading.names
+    assert "raw_id" in core_schema.RawDataParams().heading.names
+
+
+def test_user_info_round_trip(core_schema, tmp_path):
+    user_info = core_schema.UserInfo()
+    user_info.upload_user(
+        {
+            "experimenter": "ci_user",
+            "data_dir": str(tmp_path),
+            "field_loc": 0,
+            "stimulus_loc": 1,
+        },
+        verbose=0,
+    )
+
+    row = (user_info & {"experimenter": "ci_user"}).fetch1()
+    assert row["data_dir"] == f"{tmp_path}/"
+
+
+def test_add_default_raw_data_params(core_schema, tmp_path):
+    core_schema.UserInfo().upload_user(
+        {
+            "experimenter": "ci_params",
+            "data_dir": str(tmp_path),
+            "field_loc": 0,
+            "stimulus_loc": 1,
+        },
+        verbose=0,
+    )
+
+    raw_data_params = core_schema.RawDataParams()
+    raw_data_params.add_default(experimenter_list=["ci_params"])
+
+    row = (raw_data_params & {"experimenter": "ci_params"}).fetch1()
+    assert row["raw_id"] == 1
+    assert row["compute_from_stack"] == 1

--- a/tests/integration/test_tutorial_pipeline.py
+++ b/tests/integration/test_tutorial_pipeline.py
@@ -1,0 +1,107 @@
+import os
+
+import h5py
+import numpy as np
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DJ_TEST_MYSQL") != "1",
+    reason="requires the MySQL integration-test service",
+)
+
+
+def test_tutorial_pipeline(tutorial_schema, tutorial_data_dir):
+    experiment_key = {"experimenter": "synthetic"}
+
+    tutorial_schema.UserInfo().upload_user(
+        {
+            **experiment_key,
+            "data_dir": str(tutorial_data_dir),
+            "datatype_loc": 0,
+            "animal_loc": 1,
+            "region_loc": 2,
+            "field_loc": 3,
+            "stimulus_loc": 4,
+            "cond1_loc": 5,
+            "cond2_loc": 6,
+            "cond3_loc": 7,
+        },
+        verbose=0,
+    )
+    tutorial_schema.RawDataParams().add_default(experimenter_list=["synthetic"])
+
+    tutorial_schema.Experiment().rescan_filesystem(restrictions=experiment_key, verboselvl=0)
+    tutorial_schema.Field().rescan_filesystem(restrictions=experiment_key, verboselvl=0)
+
+    tutorial_schema.Stimulus().add_nostim(skip_duplicates=True)
+    tutorial_schema.Stimulus().add_chirp(
+        spatialextent=1000,
+        stim_name="gChirp",
+        alias="chirp_gchirp_globalchirp",
+        skip_duplicates=True,
+    )
+    tutorial_schema.Stimulus().add_chirp(
+        spatialextent=300,
+        stim_name="lChirp",
+        alias="lchirp_localchirp",
+        skip_duplicates=True,
+    )
+    with h5py.File(tutorial_data_dir / "resources" / "noise.h5", "r") as h5_file:
+        noise_stimulus = h5_file["stimulusarray"][:].T.astype(int)
+    tutorial_schema.Stimulus().add_noise(
+        stim_name="noise",
+        pix_n_x=20,
+        pix_n_y=15,
+        pix_scale_x_um=30,
+        pix_scale_y_um=30,
+        stim_trace=noise_stimulus,
+        skip_duplicates=True,
+    )
+    tutorial_schema.Stimulus().add_movingbar(skip_duplicates=True)
+
+    tutorial_schema.Presentation().populate(display_progress=False)
+    tutorial_schema.RoiMask().rescan_filesystem(
+        restrictions=experiment_key,
+        verboselvl=0,
+        roi_mask_dir="AutoROIs",
+    )
+    tutorial_schema.Roi().populate(experiment_key, display_progress=False)
+    tutorial_schema.Traces().populate(experiment_key, display_progress=False)
+    tutorial_schema.PreprocessParams().add_default(skip_duplicates=True)
+    tutorial_schema.PreprocessTraces().populate(experiment_key, display_progress=False)
+    tutorial_schema.Snippets().populate(experiment_key, display_progress=False)
+    tutorial_schema.Averages().populate(experiment_key, display_progress=False)
+    tutorial_schema.ChirpQI().populate(experiment_key, display_progress=False)
+
+    np.random.seed(42)
+    tutorial_schema.OsDsIndexes().populate(experiment_key, display_progress=False)
+
+    tutorial_schema.OpticDisk().populate(experiment_key, display_progress=False)
+    tutorial_schema.RelativeFieldLocation().populate(experiment_key, display_progress=False)
+    tutorial_schema.RetinalFieldLocation().populate(experiment_key, display_progress=False)
+
+    expected_counts = {
+        tutorial_schema.Experiment(): 1,
+        tutorial_schema.Field(): 1,
+        tutorial_schema.Presentation(): 3,
+        tutorial_schema.RoiMask(): 1,
+        tutorial_schema.RoiMask.RoiMaskPresentation(): 3,
+        tutorial_schema.Roi(): 2,
+        tutorial_schema.Traces(): 6,
+        tutorial_schema.PreprocessTraces(): 6,
+        tutorial_schema.Snippets(): 4,
+        tutorial_schema.Averages(): 4,
+        tutorial_schema.ChirpQI(): 2,
+        tutorial_schema.OsDsIndexes(): 2,
+        tutorial_schema.OpticDisk(): 1,
+        tutorial_schema.RelativeFieldLocation(): 1,
+        tutorial_schema.RetinalFieldLocation(): 1,
+    }
+    for table, expected_count in expected_counts.items():
+        assert len(table & experiment_key) == expected_count, table.full_table_name
+
+    assert np.all((tutorial_schema.Presentation() & experiment_key).fetch("trigger_valid") == 1)
+    assert np.all(np.isfinite((tutorial_schema.ChirpQI() & experiment_key).fetch("qidx")))
+    assert np.all(np.isfinite((tutorial_schema.OsDsIndexes() & experiment_key).fetch("ds_index")))
+    assert np.all(np.isfinite((tutorial_schema.OsDsIndexes() & experiment_key).fetch("os_index")))

--- a/tests/integration/test_tutorial_pipeline.py
+++ b/tests/integration/test_tutorial_pipeline.py
@@ -4,6 +4,8 @@ import h5py
 import numpy as np
 import pytest
 
+from tests.fixtures.random_utils import numpy_seed
+
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("DJ_TEST_MYSQL") != "1",
@@ -74,8 +76,8 @@ def test_tutorial_pipeline(tutorial_schema, tutorial_data_dir):
     tutorial_schema.Averages().populate(experiment_key, display_progress=False)
     tutorial_schema.ChirpQI().populate(experiment_key, display_progress=False)
 
-    np.random.seed(42)
-    tutorial_schema.OsDsIndexes().populate(experiment_key, display_progress=False)
+    with numpy_seed(42):
+        tutorial_schema.OsDsIndexes().populate(experiment_key, display_progress=False)
 
     tutorial_schema.OpticDisk().populate(experiment_key, display_progress=False)
     tutorial_schema.RelativeFieldLocation().populate(experiment_key, display_progress=False)
@@ -98,8 +100,15 @@ def test_tutorial_pipeline(tutorial_schema, tutorial_data_dir):
         tutorial_schema.RelativeFieldLocation(): 1,
         tutorial_schema.RetinalFieldLocation(): 1,
     }
+    count_mismatches = {}
     for table, expected_count in expected_counts.items():
-        assert len(table & experiment_key) == expected_count, table.full_table_name
+        observed_count = len(table & experiment_key)
+        if observed_count != expected_count:
+            count_mismatches[table.full_table_name] = {
+                "expected": expected_count,
+                "observed": observed_count,
+            }
+    assert not count_mismatches, f"Unexpected table counts: {count_mismatches}"
 
     assert np.all((tutorial_schema.Presentation() & experiment_key).fetch("trigger_valid") == 1)
     assert np.all(np.isfinite((tutorial_schema.ChirpQI() & experiment_key).fetch("qidx")))

--- a/tests/tables/test_orientation_synthetic.py
+++ b/tests/tables/test_orientation_synthetic.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from djimaging.tables.response.movingbar.orientation_utils_v2 import compute_os_ds_idxs
+from tests.fixtures.random_utils import numpy_seed
 
 
 DIRECTIONS_DEG = np.array([0, 180, 45, 225, 90, 270, 135, 315])
@@ -33,14 +34,14 @@ def _synthetic_snippets(tuning: str) -> tuple[np.ndarray, np.ndarray]:
 
 def test_direction_selective_response():
     snippets, direction_order = _synthetic_snippets("direction")
-    np.random.seed(42)
 
-    result = compute_os_ds_idxs(
-        snippets=snippets,
-        dir_order=direction_order,
-        dt=DT,
-        n_shuffles=256,
-    )
+    with numpy_seed(42):
+        result = compute_os_ds_idxs(
+            snippets=snippets,
+            dir_order=direction_order,
+            dt=DT,
+            n_shuffles=256,
+        )
     dsi, p_dsi, _, preferred_direction, osi, p_osi = result[:6]
 
     expected_dsi = 0.5 * (np.pi / 4) / (2 * np.sin(np.pi / 8))
@@ -53,14 +54,14 @@ def test_direction_selective_response():
 
 def test_orientation_selective_non_directional_response():
     snippets, direction_order = _synthetic_snippets("orientation")
-    np.random.seed(42)
 
-    result = compute_os_ds_idxs(
-        snippets=snippets,
-        dir_order=direction_order,
-        dt=DT,
-        n_shuffles=256,
-    )
+    with numpy_seed(42):
+        result = compute_os_ds_idxs(
+            snippets=snippets,
+            dir_order=direction_order,
+            dt=DT,
+            n_shuffles=256,
+        )
     dsi, p_dsi, _, _, osi, p_osi, _, preferred_orientation = result[:8]
 
     expected_osi = 0.5 * (np.pi / 2) / (2 * np.sin(np.pi / 4))

--- a/tests/tables/test_orientation_synthetic.py
+++ b/tests/tables/test_orientation_synthetic.py
@@ -1,0 +1,71 @@
+import numpy as np
+
+from djimaging.tables.response.movingbar.orientation_utils_v2 import compute_os_ds_idxs
+
+
+DIRECTIONS_DEG = np.array([0, 180, 45, 225, 90, 270, 135, 315])
+DT = 0.128
+
+
+def _synthetic_snippets(tuning: str) -> tuple[np.ndarray, np.ndarray]:
+    times = np.arange(32) * DT
+    time_kernel = (
+        np.exp(-((times - 1.7) / 0.45) ** 2)
+        + 0.4 * np.exp(-((times - 3.0) / 0.3) ** 2)
+    )
+
+    directions_rad = np.deg2rad(DIRECTIONS_DEG)
+    if tuning == "direction":
+        gains = 1 + 0.8 * np.cos(directions_rad)
+    elif tuning == "orientation":
+        gains = 1 + 0.8 * np.cos(2 * (directions_rad - np.deg2rad(45)))
+    else:
+        raise ValueError(tuning)
+
+    snippets = []
+    direction_order = []
+    for repeat_gain in (0.95, 1.0, 1.05):
+        snippets.extend(time_kernel * gain * repeat_gain for gain in gains)
+        direction_order.extend(DIRECTIONS_DEG)
+
+    return np.stack(snippets, axis=1), np.asarray(direction_order)
+
+
+def test_direction_selective_response():
+    snippets, direction_order = _synthetic_snippets("direction")
+    np.random.seed(42)
+
+    result = compute_os_ds_idxs(
+        snippets=snippets,
+        dir_order=direction_order,
+        dt=DT,
+        n_shuffles=256,
+    )
+    dsi, p_dsi, _, preferred_direction, osi, p_osi = result[:6]
+
+    expected_dsi = 0.5 * (np.pi / 4) / (2 * np.sin(np.pi / 8))
+    assert np.isclose(dsi, expected_dsi)
+    assert np.isclose(preferred_direction, 0)
+    assert np.isclose(osi, 0, atol=1e-12)
+    assert p_dsi == 0
+    assert p_osi > 0.5
+
+
+def test_orientation_selective_non_directional_response():
+    snippets, direction_order = _synthetic_snippets("orientation")
+    np.random.seed(42)
+
+    result = compute_os_ds_idxs(
+        snippets=snippets,
+        dir_order=direction_order,
+        dt=DT,
+        n_shuffles=256,
+    )
+    dsi, p_dsi, _, _, osi, p_osi, _, preferred_orientation = result[:8]
+
+    expected_osi = 0.5 * (np.pi / 2) / (2 * np.sin(np.pi / 4))
+    assert np.isclose(dsi, 0, atol=1e-12)
+    assert np.isclose(osi, expected_osi)
+    assert np.isclose(preferred_orientation, np.deg2rad(45))
+    assert p_dsi > 0.5
+    assert p_osi == 0

--- a/tests/test_synthetic_scanm.py
+++ b/tests/test_synthetic_scanm.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from tests.fixtures.synthetic_scanm import (
+    EXPERIMENT_DAY,
+    EXPERIMENT_NUMBER,
+    RECORDING_PREFIX,
+    RECORDING_SPECS,
+    generate_tutorial_dataset,
+)
+
+
+def test_generate_tutorial_dataset(tmp_path: Path):
+    data_dir = generate_tutorial_dataset(tmp_path / "synthetic-scanm-data")
+    experiment_dir = data_dir / EXPERIMENT_DAY / EXPERIMENT_NUMBER
+    pre_dir = experiment_dir / "Pre"
+
+    assert (experiment_dir / "synthetic__left.ini").is_file()
+    assert (data_dir / "resources" / "noise.h5").is_file()
+    assert len(list(pre_dir.glob("*.h5"))) == 3
+
+    for stimulus, spec in RECORDING_SPECS.items():
+        with h5py.File(pre_dir / f"{RECORDING_PREFIX}_{stimulus}_TEST.h5", "r") as h5_file:
+            assert set(h5_file) == {
+                "OS_Parameters",
+                "ROIs",
+                "Traces0_raw",
+                "Tracetimes0",
+                "Triggertimes",
+                "Triggervalues",
+                "wDataCh0",
+                "wDataCh1",
+                "wDataCh2",
+                "wParamsNum",
+            }
+            assert h5_file["wDataCh0"].shape == (8, 8, spec["n_frames"])
+            assert h5_file["Triggertimes"].shape == (len(spec["trigger_times"]),)
+            assert np.array_equal(np.unique(h5_file["ROIs"][:]), [-2, -1, 1])
+
+    total_size = sum(path.stat().st_size for path in data_dir.rglob("*") if path.is_file())
+    assert total_size < 3 * 1024 * 1024

--- a/tests/utils/test_scanm_synthetic.py
+++ b/tests/utils/test_scanm_synthetic.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from typing import Callable
+
+import h5py
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from djimaging.utils.scanm import read_h5_utils, traces_and_triggers_utils, wparams_utils
+from tests.fixtures.synthetic_scanm import PIXEL_DURATION_US, expected_trace_times
+
+
+def test_compute_traces_synthetic(synthetic_recording_path: Callable[[str], Path]):
+    with h5py.File(synthetic_recording_path("chirp"), "r", driver="stdio") as h5_file:
+        wparams = read_h5_utils.extract_wparams(h5_file)
+        expected_traces, stored_trace_times = read_h5_utils.extract_traces(h5_file)
+        os_params = read_h5_utils.extract_os_params(h5_file)
+        stack = np.copy(h5_file["wDataCh0"])
+        roi_mask = read_h5_utils.extract_roi_mask(h5_file)
+
+    _, traces, _, _ = traces_and_triggers_utils.compute_traces(
+        stack=stack, roi_mask=roi_mask, wparams=wparams
+    )
+
+    assert_allclose(traces, expected_traces)
+    assert_allclose(
+        stored_trace_times - os_params["stimulatordelay"] / 1000,
+        expected_trace_times(roi_mask, stack.shape[2], precision="line"),
+    )
+
+
+@pytest.mark.parametrize("precision", ["line", "pixel"])
+def test_compute_tracetimes_synthetic(
+        synthetic_recording_path: Callable[[str], Path], precision: str):
+    with h5py.File(synthetic_recording_path("chirp"), "r", driver="stdio") as h5_file:
+        wparams = read_h5_utils.extract_wparams(h5_file)
+        stack = np.copy(h5_file["wDataCh0"])
+        roi_mask = read_h5_utils.extract_roi_mask(h5_file)
+
+    _, _, trace_times, _ = traces_and_triggers_utils.compute_traces(
+        stack=stack, roi_mask=roi_mask, wparams=wparams, precision=precision
+    )
+
+    assert_allclose(
+        trace_times,
+        expected_trace_times(roi_mask, stack.shape[2], precision=precision),
+    )
+
+
+@pytest.mark.parametrize("stimulus", ["MB", "chirp", "DN"])
+@pytest.mark.parametrize("precision", ["line", "pixel"])
+def test_compute_triggertimes_synthetic(
+        synthetic_recording_path: Callable[[str], Path], stimulus: str, precision: str):
+    with h5py.File(synthetic_recording_path(stimulus), "r", driver="stdio") as h5_file:
+        wparams = read_h5_utils.extract_wparams(h5_file)
+        expected_times, expected_values = read_h5_utils.extract_triggers(
+            h5_file, check_triggervalues=True
+        )
+        trigger_stack = np.copy(h5_file["wDataCh2"])
+
+    trigger_times, trigger_values = wparams_utils.compute_triggers_from_wparams(
+        stack=trigger_stack,
+        wparams=wparams,
+        precision=precision,
+        stimulator_delay=0.,
+    )
+
+    # wParamsNum uses ScanM's float32 metadata, which accumulates a few
+    # microseconds of rounding over the longest synthetic recording.
+    atol = PIXEL_DURATION_US * 1e-6 if precision == "line" else 5e-6
+    assert_allclose(trigger_times, expected_times, atol=atol, rtol=0)
+    assert_allclose(trigger_values, expected_values)

--- a/tests/utils/test_scanm_utils.py
+++ b/tests/utils/test_scanm_utils.py
@@ -10,11 +10,6 @@ from djimaging.utils.scanm import read_h5_utils, setup_utils, traces_and_trigger
 
 _TEST_DATA_PATH = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..', 'test_data'))
 
-pytestmark = pytest.mark.skipif(
-    not os.path.isdir(_TEST_DATA_PATH),
-    reason="test_data directory not found (skipped on CI)"
-)
-
 
 def test_get_pixel_size_um_64_default_scan1():
     setupid = 1


### PR DESCRIPTION
Added integration tests and local test instructions that run against datajoint 0.14, and would fail for datajoint 2.x. This makes it easier to upgrade to datajoint 2.x in the future while confirming that we do not break the main functionality.

Changes:
- Add synthetic data generation
- Add integration test workflow in the github CI that has access to an empty mysql database
- Add local testing instruction to README
- Note: this was mostly done with codex + claude for review while ensuring that we only touch testing code and do not delete relevant testing code that existed previously.